### PR TITLE
fix issue #60

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -39,11 +39,13 @@ jobs:
       run: python -m pip install "dist/pyhp_core-$(python setup.py --version)-py3-none-any.whl[CONFIG,PHP]"
       shell: bash
 
-    - name: run tests
-      run: coverage run -m unittest discover --verbose
+    - name: run tests and generate report
+      run: |
+        coverage run -m unittest discover --verbose
+        coverage xml
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         flags: ${{ runner.os }}
   


### PR DESCRIPTION
Update worksflows to use codecov-action v2 to prevent brownouts.
The new version does not call `coverage xml` anymore, which is now
done after running the tests.
closes #60 